### PR TITLE
Move HTTP error to IOTA const

### DIFF
--- a/http/handler/error.go
+++ b/http/handler/error.go
@@ -2,47 +2,59 @@ package handler
 
 import "net/http"
 
+type errorResponseCode int
+
+const (
+	internalServerErrorCode errorResponseCode = iota + 1
+	invalidIDCode
+	malformedRequestBodyCode
+	requestValidationFailedCode
+	webhookNotFoundCode
+	deliveryNotFoundCode
+	deliveryAttemptNotFoundCode
+)
+
 var errorResponses = map[string]errorResponse{
 	"internal_server_error": {
-		Code:       1,
+		Code:       internalServerErrorCode,
 		Message:    "internal server error",
 		StatusCode: http.StatusInternalServerError,
 	},
 	"invalid_id": {
-		Code:       2,
+		Code:       invalidIDCode,
 		Message:    "invalid id",
 		StatusCode: http.StatusNotFound,
 	},
 	"malformed_request_body": {
-		Code:       3,
+		Code:       malformedRequestBodyCode,
 		Message:    "malformed request body",
 		StatusCode: http.StatusBadRequest,
 	},
 	"request_validation_failed": {
-		Code:       4,
+		Code:       requestValidationFailedCode,
 		Message:    "request validation failed",
 		StatusCode: http.StatusBadRequest,
 	},
 	"webhook_not_found": {
-		Code:       5,
+		Code:       webhookNotFoundCode,
 		Message:    "webhook not found",
 		StatusCode: http.StatusNotFound,
 	},
 	"delivery_not_found": {
-		Code:       6,
+		Code:       deliveryNotFoundCode,
 		Message:    "delivery not found",
 		StatusCode: http.StatusNotFound,
 	},
 	"delivery_attempt_not_found": {
-		Code:       7,
+		Code:       deliveryAttemptNotFoundCode,
 		Message:    "delivery attempt not found",
 		StatusCode: http.StatusNotFound,
 	},
 }
 
 type errorResponse struct {
-	Code       int    `json:"code"`
-	Message    string `json:"message"`
-	Details    string `json:"details,omitempty"`
-	StatusCode int    `json:"-"`
+	Code       errorResponseCode `json:"code"`
+	Message    string            `json:"message"`
+	Details    string            `json:"details,omitempty"`
+	StatusCode int               `json:"-"`
 } //@name Error


### PR DESCRIPTION
# What is the purpose of this pull request?

The goal of this pull request is to improve the HTTP handler error codes by applying [iota](https://github.com/golang/go/wiki/Iota) constants instead of hardcoded values.

## References:

- [Magic number](https://github.com/tommy-muehle/go-mnd#go-mnd---magic-number-detector-for-golang)